### PR TITLE
Make entry route a Laravel fallback route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,7 @@ Route::group(['middleware' => ['web'], 'namespace' => 'Bjuppa\LaravelBlog\Http\C
         Route::group($group_attributes, function () use ($blog) {
             Route::get('/', 'ListEntriesController@showIndex')->name($blog->prefixRouteName('index'));
             Route::get('feed', 'FeedController')->name($blog->prefixRouteName('feed'));
-            Route::get('{slug}', 'ShowEntryController')->name($blog->prefixRouteName('entry'));
+            Route::get('{slug}', 'ShowEntryController')->name($blog->prefixRouteName('entry'))->fallback();
         });
     });
 });


### PR DESCRIPTION
Fallback routes have been available since Laravel 5.5.5
https://github.com/laravel/framework/commit/f03e9c9b0aef1c241f3f509f08a10c683363486c

Fixes #19