### PR TITLE
Fix blog intro on narrow devices

### DIFF
--- a/resources/sass/_blog.scss
+++ b/resources/sass/_blog.scss
@@ -89,7 +89,6 @@
 
   > :first-child {
     flex: 1 1 auto;
-    min-width: $readable-line-length-min;
   }
 
   > :last-child {


### PR DESCRIPTION
On a small screen the `min-width` makes the text in intro overflow, so removing it.