### PR TITLE
Improve summary extractor

### DIFF
--- a/src/Eloquent/BlogEntry.php
+++ b/src/Eloquent/BlogEntry.php
@@ -220,7 +220,7 @@ class BlogEntry extends AbstractBlogEntry
             return new MarkdownString($this->summary);
         }
 
-        $paragraphs = SummaryExtractor::splitParagraphs($this->getContent())->split(3)->first();
+        $paragraphs = SummaryExtractor::extractParagraphs($this->getContent())->split(3)->first();
         $paragraphs = SummaryExtractor::takeWithCharacterThreshold($paragraphs);
         $paragraphs->push(SummaryExtractor::truncateParagraph($paragraphs->pop()));
 

--- a/src/Support/SummaryExtractor.php
+++ b/src/Support/SummaryExtractor.php
@@ -8,6 +8,16 @@ use Illuminate\Support\Collection;
 class SummaryExtractor
 {
     /**
+     * Get a regular expression matching a specific html element
+     * @param string $tag Name of tag
+     * @return string
+     */
+    protected static function htmlTagPattern($tag)
+    {
+        return "/<$tag(\s+(\w+)\s*=\s*(\".*?\"|'.*?'|[^>\"'\s]+))*\s*>.*?<\/$tag>/s";
+    }
+
+    /**
      * Split html string into chunks of one paragraph tag each.
      * @param string|Htmlable $html
      * @return Collection
@@ -17,8 +27,7 @@ class SummaryExtractor
         if ($html instanceof Htmlable) {
             $html = $html->toHtml();
         }
-
-        preg_match_all('/<p(\s[^>]+)?\s*>.*?<\/p>/s', $html, $matches);
+        preg_match_all(self::htmlTagPattern('p'), $html, $matches);
         return collect($matches[0]);
     }
 

--- a/src/Support/SummaryExtractor.php
+++ b/src/Support/SummaryExtractor.php
@@ -12,13 +12,14 @@ class SummaryExtractor
      * @param string|Htmlable $html
      * @return Collection
      */
-    public static function splitParagraphs($html): Collection
+    public static function extractParagraphs($html): Collection
     {
         if ($html instanceof Htmlable) {
             $html = $html->toHtml();
         }
 
-        return collect(preg_split('/(?<=<\/p>)\s*(?=<p(?:>|\s))/', $html));
+        preg_match_all('/<p(\s[^>]+)?\s*>.*?<\/p>/s', $html, $matches);
+        return collect($matches[0]);
     }
 
     /**

--- a/tests/Unit/SummaryExtractorTest.php
+++ b/tests/Unit/SummaryExtractorTest.php
@@ -19,7 +19,17 @@ class SummaryExtractorTest extends UnitTest
         $this->assertEquals("<p>4</p>", $ps->get(3));
     }
 
-    public function test_children_paragraphs_are_extracted()
+    public function test_paragraph_extraction_is_unaffected_by_lg_in_attribute()
+    {
+        $html_string = "<p a='>'>1</p><p>2</p>";
+        $ps = SummaryExtractor::extractParagraphs($html_string);
+
+        $this->assertCount(2, $ps);
+        $this->assertEquals("<p a='>'>1</p>", $ps->get(0));
+        $this->assertEquals("<p>2</p>", $ps->get(1));
+    }
+
+    public function test_child_paragraphs_are_extracted()
     {
         $html_string = "<p>1</p><div><p>A</p><p>B</p></div><p>2</p>";
         $ps = SummaryExtractor::extractParagraphs($html_string);

--- a/tests/Unit/SummaryExtractorTest.php
+++ b/tests/Unit/SummaryExtractorTest.php
@@ -7,10 +7,10 @@ use Bjuppa\LaravelBlog\Tests\UnitTest;
 
 class SummaryExtractorTest extends UnitTest
 {
-    public function test_splitting_paragraphs()
+    public function test_top_level_paragraphs_are_extracted()
     {
         $html_string = "<p>1</p><p a='b'>2</p> <p>3</p>\n<p>4</p>";
-        $ps = SummaryExtractor::splitParagraphs($html_string);
+        $ps = SummaryExtractor::extractParagraphs($html_string);
 
         $this->assertCount(4, $ps);
         $this->assertEquals("<p>1</p>", $ps->get(0));
@@ -19,5 +19,15 @@ class SummaryExtractorTest extends UnitTest
         $this->assertEquals("<p>4</p>", $ps->get(3));
     }
 
-    //TODO: test splitting <p>1</p><div><p>A</p><p>B</p></div><p>2</p> and make sure it doesn't split the nested paragraphs
+    public function test_children_paragraphs_are_extracted()
+    {
+        $html_string = "<p>1</p><div><p>A</p><p>B</p></div><p>2</p>";
+        $ps = SummaryExtractor::extractParagraphs($html_string);
+
+        $this->assertCount(4, $ps);
+        $this->assertEquals("<p>1</p>", $ps->get(0));
+        $this->assertEquals("<p>A</p>", $ps->get(1));
+        $this->assertEquals("<p>B</p>", $ps->get(2));
+        $this->assertEquals("<p>2</p>", $ps->get(3));
+    }
 }


### PR DESCRIPTION
This PR makes the summary extractor extract all `<p>` tags from html, no matter how deep.
The previous extractor could fail if paragraphs were deeper into the html.