### PR TITLE
Fix image url extraction

### DIFF
--- a/src/Eloquent/BlogEntry.php
+++ b/src/Eloquent/BlogEntry.php
@@ -202,8 +202,8 @@ class BlogEntry extends AbstractBlogEntry
         }
 
         // Match quotes or opening parenthesis with matching end
-        // Within that, capture http:// or https:// or just // and all following non-space characters into subpattern 3
-        if (preg_match('/((\'|")|\()((https?:)?\/\/\S+).*(?(2)\2|\))/s', $this->image, $matches)) {
+        // Within that, capture http:// or https:// or just // and all following non-ending characters into subpattern 3
+        if (preg_match('/((\'|")|\()((https?:)?\/\/.+?)(?(2)\2|(\)|\s))/', $this->image, $matches)) {
             return $matches[3];
         }
 

--- a/tests/Feature/BlogEntryImageTest.php
+++ b/tests/Feature/BlogEntryImageTest.php
@@ -46,6 +46,22 @@ class BlogEntryImageTest extends IntegrationTest
         $this->assertEquals($this->example_image_url, $entry->getImageUrl());
     }
 
+    public function test_quoted_image_url_can_contain_spaces()
+    {
+        $url = 'http://test.com/this and that';
+        $entry = $this->setEntryImage('<img src="' . $url . '">');
+
+        $this->assertEquals($url, $entry->getImageUrl());
+    }
+
+    public function test_quoted_image_url_can_contain_parenthesis()
+    {
+        $url = 'http://test.com/this(and)that';
+        $entry = $this->setEntryImage('<img src="' . $url . '">');
+
+        $this->assertEquals($url, $entry->getImageUrl());
+    }
+
     public function test_image_url()
     {
         $this->setEntryImage($this->example_image_url);

--- a/tests/Feature/BlogEntryImageTest.php
+++ b/tests/Feature/BlogEntryImageTest.php
@@ -21,6 +21,29 @@ class BlogEntryImageTest extends IntegrationTest
         $entry = BlogEntry::first();
         $entry->image = $content;
         $entry->save();
+
+        return $entry;
+    }
+
+    public function test_image_url_can_be_extracted_from_string()
+    {
+        $entry = $this->setEntryImage($this->example_image_url);
+
+        $this->assertEquals($this->example_image_url, $entry->getImageUrl());
+    }
+
+    public function test_image_url_can_be_extracted_from_markdown()
+    {
+        $entry = $this->setEntryImage('![Alt text](' . $this->example_image_url . ')');
+
+        $this->assertEquals($this->example_image_url, $entry->getImageUrl());
+    }
+
+    public function test_image_url_can_be_extracted_from_img_tag()
+    {
+        $entry = $this->setEntryImage('<img src="' . $this->example_image_url . '" alt="Example image">');
+
+        $this->assertEquals($this->example_image_url, $entry->getImageUrl());
     }
 
     public function test_image_url()


### PR DESCRIPTION
This PR fixes a bug in the regex that resulted in a `"` at the end of extracted image urls when there was another html attribute after the `src` attribute.

Closes #64 